### PR TITLE
accept deposit

### DIFF
--- a/src/bridge/tests/deposit_test.cairo
+++ b/src/bridge/tests/deposit_test.cairo
@@ -1,0 +1,79 @@
+use piltover::messaging::interface::IMessagingDispatcherTrait;
+use starknet_bridge::bridge::token_bridge::TokenBridge::{
+    __member_module_appchain_bridge::InternalContractMemberStateTrait,
+    __member_module_token_settings::InternalContractMemberStateTrait as tokenSettingsStateTrait,
+    TokenBridgeInternal
+};
+use snforge_std as snf;
+use snforge_std::{ContractClassTrait};
+use starknet::{ContractAddress, storage::StorageMemberAccessTrait};
+use starknet_bridge::mocks::{
+    messaging::{IMockMessagingDispatcherTrait, IMockMessagingDispatcher}, erc20::ERC20, hash
+};
+use piltover::messaging::interface::IMessagingDispatcher;
+use starknet_bridge::bridge::{
+    ITokenBridge, ITokenBridgeAdmin, ITokenBridgeDispatcher, ITokenBridgeDispatcherTrait,
+    ITokenBridgeAdminDispatcher, ITokenBridgeAdminDispatcherTrait, IWithdrawalLimitStatusDispatcher,
+    IWithdrawalLimitStatusDispatcherTrait, TokenBridge, TokenBridge::Event,
+    types::{TokenStatus, TokenSettings},
+    tests::constants::{OWNER, L3_BRIDGE_ADDRESS, USDC_MOCK_ADDRESS, DELAY_TIME}
+};
+use openzeppelin::{
+    token::erc20::interface::{
+        IERC20, IERC20Dispatcher, IERC20DispatcherTrait, IERC20MetadataDispatcher,
+        IERC20MetadataDispatcherTrait
+    },
+    access::ownable::{
+        OwnableComponent, OwnableComponent::Event as OwnableEvent,
+        interface::{IOwnableTwoStepDispatcher, IOwnableTwoStepDispatcherTrait}
+    }
+};
+use starknet_bridge::bridge::tests::utils::message_payloads;
+use starknet::contract_address::{contract_address_const};
+use starknet_bridge::constants;
+use starknet_bridge::bridge::tests::utils::setup::{
+    deploy_erc20, deploy_token_bridge_with_messaging, deploy_token_bridge, enroll_token_and_settle,
+    mock_state_testing
+};
+
+fn setup() -> (TokenBridge::ContractState, ContractAddress) {
+    let mut mock = mock_state_testing();
+    let usdc_address = deploy_erc20("usdc", "usdc");
+    (mock, usdc_address)
+}
+
+
+#[test]
+#[should_panic(expected: ('ERC20: insufficient balance',))]
+fn accept_deposit_insufficient_balance() {
+    let (mut mock, usdc_address) = setup();
+    let usdc = IERC20Dispatcher { contract_address: usdc_address };
+    // Setting the token active
+    let old_settings = mock.token_settings.read(usdc_address);
+    mock
+        .token_settings
+        .write(usdc_address, TokenSettings { token_status: TokenStatus::Active, ..old_settings });
+    snf::start_cheat_caller_address_global(snf::test_address());
+    usdc.approve(snf::test_address(), 200);
+    mock.accept_deposit(usdc_address, 200);
+}
+
+#[test]
+#[should_panic(expected: ('ERC20: insufficient allowance',))]
+fn accept_deposit_insufficient_allowance() {
+    let (mut mock, usdc_address) = setup();
+    // Setting the token active
+    let old_settings = mock.token_settings.read(usdc_address);
+    mock
+        .token_settings
+        .write(usdc_address, TokenSettings { token_status: TokenStatus::Active, ..old_settings });
+    mock.accept_deposit(usdc_address, 100);
+}
+
+#[test]
+#[should_panic(expected: ('Only servicing tokens',))]
+fn accept_deposit_not_servicing() {
+    let (mock, usdc_address) = setup();
+    mock.accept_deposit(usdc_address, 200);
+}
+

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -8,6 +8,8 @@ pub mod bridge {
         pub mod constants;
         mod token_actions_test;
         mod messaging_test;
+
+        mod deposit_test;
         pub mod utils {
             pub mod message_payloads;
             pub mod setup;

--- a/tests/deposit_test.cairo
+++ b/tests/deposit_test.cairo
@@ -64,41 +64,6 @@ fn deposit_ok() {
     spy.assert_emitted(@array![(token_bridge.contract_address, Event::Deposit(expected_deposit))]);
 }
 
-
-#[test]
-#[should_panic(expected: ('ERC20: insufficient balance',))]
-fn deposit_insufficient_balance() {
-    let (token_bridge, _, usdc_address, _) = setup();
-    let usdc = IERC20Dispatcher { contract_address: usdc_address };
-
-    usdc.approve(token_bridge.contract_address, 200);
-    token_bridge.deposit(usdc_address, 200, snf::test_address());
-}
-
-#[test]
-#[should_panic(expected: ('ERC20: insufficient allowance',))]
-fn deposit_insufficient_allowance() {
-    let (token_bridge, _, usdc_address, _) = setup();
-    token_bridge.deposit(usdc_address, 100, snf::test_address());
-}
-
-
-#[test]
-#[should_panic(expected: ('Only servicing tokens',))]
-fn deposit_deactivated() {
-    let (token_bridge, _, usdc_address, _) = setup();
-    let token_bridge_admin = ITokenBridgeAdminDispatcher {
-        contract_address: token_bridge.contract_address
-    };
-
-    snf::start_cheat_caller_address(token_bridge.contract_address, OWNER());
-    token_bridge_admin.deactivate_token(usdc_address);
-    snf::stop_cheat_caller_address(OWNER());
-
-    token_bridge.deposit(usdc_address, 100, snf::test_address());
-}
-
-
 #[test]
 fn deposit_with_message_ok() {
     let (token_bridge, mut spy, usdc_address, _) = setup();
@@ -173,48 +138,6 @@ fn deposit_with_message_empty_message_ok() {
                 )
             ]
         );
-}
-
-#[test]
-#[should_panic(expected: ('ERC20: insufficient balance',))]
-fn deposit_with_message_insufficient_balance() {
-    let (token_bridge, _, usdc_address, _) = setup();
-
-    let usdc = IERC20Dispatcher { contract_address: usdc_address };
-    usdc.approve(token_bridge.contract_address, 200);
-
-    let mut calldata = ArrayTrait::new();
-    'param1'.serialize(ref calldata);
-    'param2'.serialize(ref calldata);
-    token_bridge.deposit_with_message(usdc_address, 200, snf::test_address(), calldata.span());
-}
-
-#[test]
-#[should_panic(expected: ('ERC20: insufficient allowance',))]
-fn deposit_with_message_insufficient_allowance() {
-    let (token_bridge, _, usdc_address, _) = setup();
-    let mut calldata = ArrayTrait::new();
-    'param1'.serialize(ref calldata);
-    'param2'.serialize(ref calldata);
-    token_bridge.deposit_with_message(usdc_address, 100, snf::test_address(), calldata.span());
-}
-
-#[test]
-#[should_panic(expected: ('Only servicing tokens',))]
-fn deposit_with_message_deactivated() {
-    let (token_bridge, _, usdc_address, _) = setup();
-    let token_bridge_admin = ITokenBridgeAdminDispatcher {
-        contract_address: token_bridge.contract_address
-    };
-
-    snf::start_cheat_caller_address(token_bridge.contract_address, OWNER());
-    token_bridge_admin.deactivate_token(usdc_address);
-    snf::stop_cheat_caller_address(OWNER());
-
-    let mut calldata = ArrayTrait::new();
-    'param1'.serialize(ref calldata);
-    'param2'.serialize(ref calldata);
-    token_bridge.deposit_with_message(usdc_address, 100, snf::test_address(), calldata.span());
 }
 
 


### PR DESCRIPTION
This pr tries improving the redundancy in the testcases of `deposit()` and `deposit_with_message()` by testing for the edge cases in `accept_deposit()` which is a common function called by both `deposit()` and `deposit_with_messge()`

However this might come at the costs of testcase readability and use of `Contract::contract_state_for_testing()` which may not be the best way to write testcases