### PR TITLE
Fix ByteArray Issue

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.8.0
+scarb 2.8.2
 starknet-foundry 0.27.0

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -15,6 +15,7 @@ snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v
 
 [[target.starknet-contract]]
 casm = true
+allowed-libfuncs-list.name = "experimental"
 
 
 [scripts]

--- a/src/bridge/tests/messaging_test.cairo
+++ b/src/bridge/tests/messaging_test.cairo
@@ -22,26 +22,6 @@ fn deploy_message_payload_ok() {
     let usdc_address = deploy_erc20("USDC", "USDC");
     let calldata = TokenBridge::deployment_message_payload(usdc_address);
 
-    // With byteArray
-    // [
-    //     1395567803262486866641834792347783460559299057717595230314827200011451862040,
-    //     0,
-    //     1431520323,
-    //     4,
-    //     0,
-    //     1431520323,
-    //     4,
-    //     18
-    // ]
-    //
-    // With syscall direct serialisation
-    // [
-    //       1395567803262486866641834792347783460559299057717595230314827200011451862040,
-    //       3, 0, 1431520323, 4,
-    //       3, 0, 1431520323, 4,
-    //       18
-    //   ]
-
     let expected_calldata: Span<felt252> = array![
         1395567803262486866641834792347783460559299057717595230314827200011451862040, // usdc_address
         0,

--- a/src/bridge/tests/messaging_test.cairo
+++ b/src/bridge/tests/messaging_test.cairo
@@ -10,7 +10,6 @@ use piltover::messaging::interface::IMessagingDispatcher;
 use starknet_bridge::bridge::{
     tests::constants::{L3_BRIDGE_ADDRESS, OWNER, USDC_MOCK_ADDRESS, DELAY_TIME}
 };
-
 use piltover::messaging::types::MessageToAppchainStatus;
 use starknet_bridge::bridge::tests::utils::setup::{deploy_erc20, mock_state_testing};
 use starknet_bridge::bridge::tests::utils::message_payloads;
@@ -23,17 +22,38 @@ fn deploy_message_payload_ok() {
     let usdc_address = deploy_erc20("USDC", "USDC");
     let calldata = TokenBridge::deployment_message_payload(usdc_address);
 
+    // With byteArray
+    // [
+    //     1395567803262486866641834792347783460559299057717595230314827200011451862040,
+    //     0,
+    //     1431520323,
+    //     4,
+    //     0,
+    //     1431520323,
+    //     4,
+    //     18
+    // ]
+    //
+    // With syscall direct serialisation
+    // [
+    //       1395567803262486866641834792347783460559299057717595230314827200011451862040,
+    //       3, 0, 1431520323, 4,
+    //       3, 0, 1431520323, 4,
+    //       18
+    //   ]
+
     let expected_calldata: Span<felt252> = array![
-        327360033215303420453874031627788877836422131767619347074434581266068999983, // usdc_address
+        1395567803262486866641834792347783460559299057717595230314827200011451862040, // usdc_address
         0,
-        1431520323, // -- USDC
-        4,
+        1431520323,
+        4, // "USDC"
         0,
-        1431520323, // USDC
-        4,
-        18 // Decimals
+        1431520323,
+        4, // "USDC"
+        18
     ]
         .span();
+
     assert(calldata == expected_calldata, 'Incorrect serialisation');
 }
 

--- a/src/withdrawal_limit/tests/withdrawal_limit_test.cairo
+++ b/src/withdrawal_limit/tests/withdrawal_limit_test.cairo
@@ -1,7 +1,7 @@
 use core::num::traits::Bounded;
 use snforge_std as snf;
 use snforge_std::{ContractClassTrait, EventSpy, EventSpyAssertionsTrait};
-use starknet_bridge::bridge::tests::constants::{OWNER,};
+use starknet_bridge::bridge::tests::constants::{OWNER};
 use starknet_bridge::mocks::withdrawal_limit_mock::{
     IMockWithdrawalLimitDispatcher, IMockWithdrawalLimitDispatcherTrait
 };

--- a/tests/deposit_test.cairo
+++ b/tests/deposit_test.cairo
@@ -1,34 +1,17 @@
-use core::num::traits::zero::Zero;
-use core::array::ArrayTrait;
-use core::serde::Serde;
-use core::result::ResultTrait;
-use core::option::OptionTrait;
-use core::traits::TryInto;
 use snforge_std as snf;
-use snforge_std::{
-    ContractClassTrait, EventSpy, EventSpyTrait, EventsFilterTrait, EventSpyAssertionsTrait
-};
+use snforge_std::{EventSpy, EventSpyAssertionsTrait};
 use starknet::ContractAddress;
-use starknet_bridge::mocks::{
-    messaging::{IMockMessagingDispatcherTrait, IMockMessagingDispatcher}, erc20::ERC20
-};
-use piltover::messaging::{IMessaging, IMessagingDispatcher, IMessagingDispatcherTrait};
+use starknet_bridge::mocks::messaging::IMockMessagingDispatcher;
 use starknet_bridge::bridge::{
-    ITokenBridge, ITokenBridgeAdmin, ITokenBridgeDispatcher, ITokenBridgeDispatcherTrait,
-    ITokenBridgeAdminDispatcher, ITokenBridgeAdminDispatcherTrait, IWithdrawalLimitStatusDispatcher,
-    IWithdrawalLimitStatusDispatcherTrait, TokenBridge, TokenBridge::Event,
-    types::{TokenStatus, TokenSettings}
-};
-use openzeppelin::access::ownable::{
-    OwnableComponent, OwnableComponent::Event as OwnableEvent,
-    interface::{IOwnableTwoStepDispatcher, IOwnableTwoStepDispatcherTrait}
+    ITokenBridgeDispatcher, ITokenBridgeDispatcherTrait, ITokenBridgeAdminDispatcher,
+    ITokenBridgeAdminDispatcherTrait, TokenBridge, TokenBridge::Event,
 };
 
-use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
+use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
 use starknet::contract_address::{contract_address_const};
-use super::constants::{OWNER, L3_BRIDGE_ADDRESS, DELAY_TIME};
+use super::constants::{OWNER};
 use starknet_bridge::bridge::tests::utils::setup::{
-    deploy_erc20, deploy_token_bridge_with_messaging, deploy_token_bridge, enroll_token_and_settle
+    deploy_erc20, deploy_token_bridge_with_messaging, enroll_token_and_settle
 };
 
 fn setup() -> (ITokenBridgeDispatcher, EventSpy, ContractAddress, IMockMessagingDispatcher) {

--- a/tests/enroll_token_test.cairo
+++ b/tests/enroll_token_test.cairo
@@ -1,21 +1,11 @@
 use snforge_std as snf;
-use snforge_std::{ContractClassTrait, EventSpy, EventSpyTrait, EventSpyAssertionsTrait};
-use starknet::ContractAddress;
-use starknet_bridge::mocks::{
-    messaging::{IMockMessagingDispatcherTrait, IMockMessagingDispatcher}, erc20::ERC20, hash
-};
+use snforge_std::{ContractClassTrait, EventSpyAssertionsTrait};
+use starknet_bridge::mocks::{hash};
 use starknet_bridge::bridge::{
-    ITokenBridge, ITokenBridgeAdmin, ITokenBridgeDispatcher, ITokenBridgeDispatcherTrait,
-    ITokenBridgeAdminDispatcher, ITokenBridgeAdminDispatcherTrait, IWithdrawalLimitStatusDispatcher,
-    IWithdrawalLimitStatusDispatcherTrait, TokenBridge, TokenBridge::Event,
-    types::{TokenStatus, TokenSettings}
+    ITokenBridgeDispatcher, ITokenBridgeDispatcherTrait, TokenBridge, TokenBridge::Event,
+    types::TokenStatus
 };
-use openzeppelin::access::ownable::{
-    OwnableComponent, OwnableComponent::Event as OwnableEvent,
-    interface::{IOwnableTwoStepDispatcher, IOwnableTwoStepDispatcherTrait}
-};
-use starknet::contract_address::{contract_address_const};
-use super::constants::{OWNER, L3_BRIDGE_ADDRESS, USDC_MOCK_ADDRESS, DELAY_TIME};
+use super::constants::{OWNER, L3_BRIDGE_ADDRESS};
 use starknet_bridge::bridge::tests::utils::setup::{deploy_erc20, deploy_token_bridge};
 use starknet_bridge::bridge::tests::utils::message_payloads;
 use starknet_bridge::constants;

--- a/tests/token_bridge_test.cairo
+++ b/tests/token_bridge_test.cairo
@@ -1,27 +1,15 @@
-use core::array::ArrayTrait;
-use core::serde::Serde;
-use core::result::ResultTrait;
-use core::option::OptionTrait;
-use core::traits::TryInto;
 use snforge_std as snf;
-use snforge_std::{ContractClassTrait, EventSpy, EventSpyTrait, EventSpyAssertionsTrait};
-use starknet::ContractAddress;
-use starknet_bridge::mocks::{
-    messaging::{IMockMessagingDispatcherTrait, IMockMessagingDispatcher}, erc20::ERC20
-};
+use snforge_std::EventSpyAssertionsTrait;
 use starknet_bridge::bridge::{
-    ITokenBridge, ITokenBridgeAdmin, ITokenBridgeDispatcher, ITokenBridgeDispatcherTrait,
-    ITokenBridgeAdminDispatcher, ITokenBridgeAdminDispatcherTrait, IWithdrawalLimitStatusDispatcher,
-    IWithdrawalLimitStatusDispatcherTrait, TokenBridge, TokenBridge::Event,
-    types::{TokenStatus, TokenSettings}
+    ITokenBridgeDispatcher, ITokenBridgeDispatcherTrait, ITokenBridgeAdminDispatcher,
+    ITokenBridgeAdminDispatcherTrait, TokenBridge, TokenBridge::Event,
 };
 use openzeppelin::access::ownable::{
-    OwnableComponent, OwnableComponent::Event as OwnableEvent,
     interface::{IOwnableTwoStepDispatcher, IOwnableTwoStepDispatcherTrait}
 };
 use starknet::contract_address::{contract_address_const};
-use starknet_bridge::bridge::tests::utils::setup::{deploy_erc20, deploy_token_bridge};
-use super::constants::{OWNER, L3_BRIDGE_ADDRESS, USDC_MOCK_ADDRESS, DELAY_TIME};
+use starknet_bridge::bridge::tests::utils::setup::{deploy_token_bridge};
+use super::constants::{OWNER, L3_BRIDGE_ADDRESS, USDC_MOCK_ADDRESS};
 
 
 #[test]

--- a/tests/withdraw_test.cairo
+++ b/tests/withdraw_test.cairo
@@ -3,7 +3,7 @@ use snforge_std::EventSpy;
 use starknet_bridge::mocks::{messaging::{IMockMessagingDispatcherTrait, IMockMessagingDispatcher},};
 use starknet_bridge::bridge::{
     ITokenBridgeDispatcher, ITokenBridgeDispatcherTrait, ITokenBridgeAdminDispatcher,
-    ITokenBridgeAdminDispatcherTrait, IWithdrawalLimitStatusDispatcher,
+    ITokenBridgeAdminDispatcherTrait,
 };
 
 use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};

--- a/tests/withdrawal_limit_bridge_test.cairo
+++ b/tests/withdrawal_limit_bridge_test.cairo
@@ -1,27 +1,11 @@
-use core::array::ArrayTrait;
-use core::serde::Serde;
-use core::result::ResultTrait;
-use core::option::OptionTrait;
-use core::traits::TryInto;
 use snforge_std as snf;
-use snforge_std::{ContractClassTrait, EventSpy, EventSpyTrait, EventSpyAssertionsTrait};
-use starknet::ContractAddress;
-use starknet_bridge::mocks::{
-    messaging::{IMockMessagingDispatcherTrait, IMockMessagingDispatcher}, erc20::ERC20
-};
+use snforge_std::EventSpyAssertionsTrait;
 use starknet_bridge::bridge::{
-    ITokenBridge, ITokenBridgeAdmin, ITokenBridgeDispatcher, ITokenBridgeDispatcherTrait,
     ITokenBridgeAdminDispatcher, ITokenBridgeAdminDispatcherTrait, IWithdrawalLimitStatusDispatcher,
     IWithdrawalLimitStatusDispatcherTrait, TokenBridge, TokenBridge::Event,
-    types::{TokenStatus, TokenSettings}
 };
-use openzeppelin::access::ownable::{
-    OwnableComponent, OwnableComponent::Event as OwnableEvent,
-    interface::{IOwnableTwoStepDispatcher, IOwnableTwoStepDispatcherTrait}
-};
-use starknet::contract_address::{contract_address_const};
-use super::constants::{OWNER, L3_BRIDGE_ADDRESS, USDC_MOCK_ADDRESS, DELAY_TIME};
-use starknet_bridge::bridge::tests::utils::setup::{deploy_erc20, deploy_token_bridge};
+use super::constants::{OWNER, USDC_MOCK_ADDRESS};
+use starknet_bridge::bridge::tests::utils::setup::{deploy_token_bridge};
 
 
 #[test]


### PR DESCRIPTION
This pr fixes #15. 
- If we call `name()` on a token address by wrapping it in the new trait with `ByteArray` while it is using felt interface the call would fail when the dispatcher will try to deserialize the returned Span
- So we use the underlying syscall to make the call
- We can do a different kind of serialisation after checking the the length of the span(which will 1 for the felt and at 3 for `ByteArray`). 
- But that is not required since the way to serialise is same and the deployment message is of fixed length (token_address,name,symbol,decimals) and while deserialising we could check the length of the payload to deserialise it accordingly