### PR TITLE
remove double encoding of name and symbol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ contracts*.json
 logs/
 *.log
 dist/
+config/

--- a/src/bridge/tests/messaging_test.cairo
+++ b/src/bridge/tests/messaging_test.cairo
@@ -9,7 +9,9 @@ use starknet_bridge::bridge::tests::constants::{
     TIMELOCK_ADDRESS, TOKEN_ADMIN, USDC_MOCK_ADDRESS,
 };
 use starknet_bridge::bridge::tests::utils::message_payloads;
-use starknet_bridge::bridge::tests::utils::setup::{deploy_erc20, mock_state_testing};
+use starknet_bridge::bridge::tests::utils::setup::{
+    deploy_erc20, deploy_erc20_with_felt252, mock_state_testing,
+};
 use starknet_bridge::bridge::token_bridge::TokenBridge::TokenBridgeInternal;
 use starknet_bridge::constants;
 use starknet_bridge::mocks::hash;
@@ -17,16 +19,59 @@ use starknet_bridge::mocks::messaging::{IMockMessagingDispatcher, IMockMessaging
 
 
 #[test]
-fn deploy_message_payload_ok() {
-    let usdc_address = deploy_erc20("USDC", "USDC");
+fn deploy_message_payload_1u128_ok() {
+    let usdc_address = deploy_erc20_with_felt252('USDC', 'USDC');
     let calldata = TokenBridge::deployment_message_payload(usdc_address);
 
     println!("calldata {:?}", calldata);
     let expected_calldata: Span<felt252> = array![
-        3229811236586461276790806733073987758974063646349769890211994918419655038703, // usdc_address
+        1878846678861813862807137660746142479173097938654444763365422304796849302852, // usdc_address
         0,
         1431520323,
         4, // "USDC"
+        0,
+        1431520323,
+        4, // "USDC"
+        18,
+    ]
+        .span();
+
+    assert(calldata == expected_calldata, 'Incorrect serialisation');
+}
+
+#[test]
+fn deploy_message_payload_2u128_ok() {
+    let usdc_address = deploy_erc20_with_felt252('Starknet Bridged Token USDC', 'USDC');
+    let calldata = TokenBridge::deployment_message_payload(usdc_address);
+
+    println!("calldata {:?}", calldata);
+    let expected_calldata: Span<felt252> = array![
+        1490587303571540848742139364702760394050729519911961861263204573571851472479, // token address 
+        0,
+        34331236061979135384369429850688382866543914782444172758941385795,
+        27, // "Starknet Bridged Token USDC"
+        0,
+        1431520323,
+        4, // "USDC"
+        18,
+    ]
+        .span();
+
+    assert(calldata == expected_calldata, 'Incorrect serialisation');
+}
+
+#[test]
+fn deploy_message_payload_3u128_ok() {
+    let usdc_address = deploy_erc20("Starknet Bridged Into Appchain Token USDC", "USDC");
+    let calldata = TokenBridge::deployment_message_payload(usdc_address);
+    println!("calldata {:?}", calldata);
+
+    let expected_calldata: Span<felt252> = array![
+        143620707853892322995637150357644909544175399019378012924718466488958919106, // token address
+        1,
+        147451536117456215510223090790872767498932623355471960875487237126251703840,
+        398734111865851813774403,
+        10, // "Starknet Bridged Into Appchain Token USDC"
         0,
         1431520323,
         4, // "USDC"

--- a/src/bridge/tests/utils/setup.cairo
+++ b/src/bridge/tests/utils/setup.cairo
@@ -39,6 +39,25 @@ pub fn deploy_erc20(name: ByteArray, symbol: ByteArray) -> ContractAddress {
     return usdc;
 }
 
+pub fn deploy_erc20_with_felt252(name: felt252, symbol: felt252) -> ContractAddress {
+    let erc20_class_hash = snf::declare("ERC20_FELT_NAME_SYMBOL").unwrap().contract_class();
+    let mut constructor_args = ArrayTrait::new();
+    let fixed_supply: u256 = 1000000000;
+
+    name.serialize(ref constructor_args);
+    symbol.serialize(ref constructor_args);
+    18.serialize(ref constructor_args); // decimals
+    fixed_supply.serialize(ref constructor_args);
+    OWNER().serialize(ref constructor_args);
+    OWNER().serialize(ref constructor_args);
+    OWNER().serialize(ref constructor_args);
+    10.serialize(ref constructor_args);
+
+    let (usdc, _) = erc20_class_hash.deploy(@constructor_args).unwrap();
+
+    return usdc;
+}
+
 pub fn deploy_token_bridge_with_messaging() -> (
     ITokenBridgeDispatcher, EventSpy, IMockMessagingDispatcher,
 ) {

--- a/src/bridge/token_bridge.cairo
+++ b/src/bridge/token_bridge.cairo
@@ -3,9 +3,8 @@ pub mod TokenBridge {
     use core::array::ArrayTrait;
     use core::num::traits::Bounded;
     use core::num::traits::zero::Zero;
-    use core::option::OptionTrait;
+    use core::option::{OptionTrait, Option};
     use core::serde::Serde;
-    use core::to_byte_array::FormatAsByteArray;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::access::accesscontrol::interface::IAccessControl;
     use openzeppelin::introspection::src5::SRC5Component;
@@ -480,11 +479,24 @@ pub mod TokenBridge {
         return payload.span();
     }
 
+    fn count_bytes(mut value: u128) -> usize {
+        let mut bytes = 0;
+        while value > 0 {
+            value /= 256;
+            bytes += 1;
+        };
+        bytes
+    }
+
     fn deserialize_and_append(
         mut value: Span<felt252>, mut calldata: Array<felt252>,
     ) -> Array<felt252> {
         if (value.len() == 1) {
-            let value_byte_array = value[0].format_as_byte_array(10);
+            let mut value_u256: u256 = (*value[0]).into();
+            let mut total_bytes = count_bytes(value_u256.low) + count_bytes(value_u256.high);
+
+            let mut value_byte_array: ByteArray = "";
+            value_byte_array.append_word(*value[0], total_bytes);
             value_byte_array.serialize(ref calldata);
         } else {
             let value_byte_array = Serde::<ByteArray>::deserialize(ref value).unwrap();

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -66,6 +66,9 @@ pub mod mocks {
     pub mod access_control_mock;
     pub mod erc20;
 
+    #[cfg(test)]
+    pub mod erc20_felt_name_symbol;
+
     #[cfg(target: 'test')]
     pub mod hash;
 

--- a/src/mocks/erc20_felt_name_symbol.cairo
+++ b/src/mocks/erc20_felt_name_symbol.cairo
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+///
+/// This is a mock ERC20 contract to be used only in test cases.
+/// Unlike the current OpenZeppelin recommendation, this contract returns
+/// name and symbol as felt252 instead of ByteArray.
+/// Some tokens on Starknet mainnet still use felt252 for name and symbol,
+/// so testing with this format is required for compatibility.
+
+// 💀💀💀💀💀💀💀💀💀💀💀💀💀💀
+// ! Not to be used in mainnet
+// 💀💀💀💀💀💀💀💀💀💀💀💀💀💀
+
+#[starknet::contract]
+pub mod ERC20_FELT_NAME_SYMBOL {
+    use starknet::ContractAddress;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+
+    #[storage]
+    struct Storage {
+        name: felt252,
+        symbol: felt252,
+        decimals: u8,
+        initial_supply: u256,
+        initial_recipient: ContractAddress,
+        permitted_minter: ContractAddress,
+        l2_token_governance: ContractAddress,
+        upgrade_delay: u64,
+    }
+
+    const DECIMALS: u256 = 1000000000000000000;
+
+    /// Sets the token `name` and `symbol`.
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        name: felt252,
+        symbol: felt252,
+        decimals: u8,
+        initial_supply: u256,
+        initial_recipient: ContractAddress,
+        permitted_minter: ContractAddress,
+        l2_token_governance: ContractAddress,
+        upgrade_delay: u64,
+    ) {
+        self.name.write(name);
+        self.symbol.write(symbol);
+        self.decimals.write(decimals);
+    }
+
+    #[external(v0)]
+    fn name(ref self: ContractState) -> felt252 {
+        self.name.read()
+    }
+
+    #[external(v0)]
+    fn symbol(ref self: ContractState) -> felt252 {
+        self.symbol.read()
+    }
+
+    #[external(v0)]
+    fn decimals(ref self: ContractState) -> u8 {
+        self.decimals.read()
+    }
+}


### PR DESCRIPTION
- Fixes the double encoding issue of name and symbol while enrolling the token